### PR TITLE
Remove <main> tag wrapper for v-content

### DIFF
--- a/client/components/app-layout.vue
+++ b/client/components/app-layout.vue
@@ -21,13 +21,11 @@
         <v-btn v-else :to="{name: 'user-signin'}" flat>Sign in</v-btn>
       </v-toolbar-items>
     </v-toolbar>
-    <main>
       <v-content>
         <v-container fluid>
           <router-view />
         </v-container>
       </v-content>
-    </main>
     <v-footer app>
       <a href="https://github.com/peer/doc">Source code</a>
     </v-footer>


### PR DESCRIPTION
Vuetify doesn't require a <main> tag wrapper since 1.7.x and a warning is currently triggered for doing so.
We remove the tag to avoid the warning