### PR TITLE
Remove cursor

### DIFF
--- a/client/components/editor.vue
+++ b/client/components/editor.vue
@@ -406,6 +406,7 @@
     },
     beforeDestroy() {
       window.removeEventListener('resize', this.handleWindowResize);
+      Cursor.remove({contentKey: this.contentKey, clientId: this.clientId});
     },
     methods: {
       onScroll(e) {

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -75,3 +75,8 @@ if (Meteor.isServer) {
     connectionId: 1,
   });
 }
+
+Cursor.remove = function remove(...args) {
+  args.unshift('Cursor.remove');
+  return Meteor.call(...args);
+};

--- a/server/cursor.js
+++ b/server/cursor.js
@@ -7,6 +7,18 @@ import randomColor from 'randomcolor';
 
 // Server-side only method, so we are not using ValidatedMethod.
 Meteor.methods({
+
+  'Cursor.remove'(args) {
+    check(args, {
+      contentKey: Match.DocumentId,
+      clientId: Match.DocumentId,
+    });
+    Cursor.documents.remove({
+      contentKey: args.contentKey,
+      clientId: args.clientId,
+    });
+  },
+
   'Cursor.update'(args) {
     check(args, {
       contentKey: Match.DocumentId,

--- a/server/documents/cursor.js
+++ b/server/documents/cursor.js
@@ -5,14 +5,14 @@ import {Cursor} from '/lib/documents/cursor';
 import {User} from '/lib/documents/user';
 import randomColor from 'randomcolor';
 
-// Server-side only method, so we are not using ValidatedMethod.
+// Server-side only methods, so we are not using ValidatedMethod.
 Meteor.methods({
-
   'Cursor.remove'(args) {
     check(args, {
       contentKey: Match.DocumentId,
       clientId: Match.DocumentId,
     });
+
     Cursor.documents.remove({
       contentKey: args.contentKey,
       clientId: args.clientId,

--- a/server/documents/cursor.js
+++ b/server/documents/cursor.js
@@ -16,6 +16,7 @@ Meteor.methods({
     Cursor.documents.remove({
       contentKey: args.contentKey,
       clientId: args.clientId,
+      connectionId: this.connection.id,
     });
   },
 


### PR DESCRIPTION
Added a _beforeDestroy_ hook in editor.vue for removing the current user cursor. Also, a _remove_ method was added to _lib/documents/cursor.js_ and _server/documents/cursor.js_

Fixes #49 