### PR TITLE
Slice check removed

### DIFF
--- a/server/documents/content.js
+++ b/server/documents/content.js
@@ -25,13 +25,6 @@ Meteor.methods({
 
     // TODO: Check more permissions?
 
-    args.steps.forEach((step) => {
-      if (step.slice) {
-        step.slice.content.descendants((node) => {
-          node.check(); // will throw an error if node is not valid
-        });
-      }
-    });
     let addedCount = 0;
     const latestContent = Content.documents.findOne({contentKey: args.contentKey}, {sort: {version: -1}, fields: {version: 1}});
     const document = Document.documents.findOne({contentKey: args.contentKey});


### PR DESCRIPTION
Slice check is not yet supported by prosemirror,
so server side step validation (cc83ff950a5bacd8cd3877109cdbbcf063f4535a) is removed
for the moment.

See #58 