### PR TITLE
Add comments on marked text

### DIFF
--- a/client/components/utils/add-comment-plugin.js
+++ b/client/components/utils/add-comment-plugin.js
@@ -34,8 +34,8 @@ class AddComment {
       if (!marksObj.marks.length) {
         onlyHighlightMarkInRange = false;
       }
-      if (marksObj.marks.filter((m) => {
-        return m.type.name !== 'highlight';
+      if (!marksObj.marks.filter((m) => {
+        return m.type.name === 'highlight';
       }).length) {
         onlyHighlightMarkInRange = false;
       }
@@ -48,6 +48,8 @@ class AddComment {
           return m.type.name === "highlight";
         }),
       });
+    }).filter((marksObj) => {
+      return marksObj.marks.length;
     });
     const button = this.vueInstance.$refs.addCommentButton;
     // Hide the comment button if the selection is empty or the selection


### PR DESCRIPTION
Texts with multiple marks (like bold, italics or strikethrough) were not being considered. 
Comments can now be applied to marked text. 