### PR TITLE
fill-height only when there are no comments.

### DIFF
--- a/client/components/sidebar.vue
+++ b/client/components/sidebar.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container
+    :fill-height="!documentComments.length"
     fluid
-    fill-height
     class="sidebar"
     @mousedown.stop
   >


### PR DESCRIPTION
Now fill-height is set to true only when there are no comments, so the "no comments" hint is centered. And when there are comments, fill-height is false and they are aligned again.

See #112 